### PR TITLE
Modify queue-proxy to support Firecracker microVMs

### DIFF
--- a/pkg/queue/sharedmain/handlers.go
+++ b/pkg/queue/sharedmain/handlers.go
@@ -44,7 +44,7 @@ func mainHandler(
 	stats *netstats.RequestStats,
 	logger *zap.SugaredLogger,
 ) (http.Handler, *pkghandler.Drainer) {
-	target := net.JoinHostPort("127.0.0.1", env.UserPort)
+	target := net.JoinHostPort(env.GuestAddr, env.GuestPort)
 
 	httpProxy := pkghttp.NewHeaderPruningReverseProxy(target, pkghttp.NoHostOverride, activator.RevisionHeaders, false /* use HTTP */)
 	httpProxy.Transport = transport


### PR DESCRIPTION
Patch routing in the queue-proxy to redirect messages to firecracker VM instead of the container created by k8s.